### PR TITLE
destroy::related option

### DIFF
--- a/lib/rails_admin/config/sections/destroy.rb
+++ b/lib/rails_admin/config/sections/destroy.rb
@@ -10,6 +10,10 @@ module RailsAdmin
         register_instance_option(:soft_destroy) do
           false
         end
+        # Defines if we should display the related objects on delete
+        register_instance_option(:related) do
+          true
+        end
       end
     end
   end


### PR DESCRIPTION
Sometimes we have something like this:

```
class User < ActiveRecord::Base
  belongs_to :group
end
class Group < ActiveRecord::Base
  has_many :users, :dependent => :nullify
end
```

so users are not deleted when deleting groups, but rails_admin is still displaying the warning. This is a workaround for that. Then, you can do..

```
config.model Group do
  destroy do
    related false
  end
end
```
